### PR TITLE
WIP of DiscHeaders

### DIFF
--- a/theme/Scripts/Panel_Playlist.js
+++ b/theme/Scripts/Panel_Playlist.js
@@ -3354,8 +3354,6 @@ function Header(x, y, w, h, idx, row_h_arg) {
 Header.prototype = Object.create(List.Item.prototype);
 Header.prototype.constructor = Header;
 
-var show_disc_headers = true;
-
 function DiscHeader(x, y, w, h, metadb, header) {
     List.Item.call(this, x, y, w, h);
 
@@ -3519,9 +3517,6 @@ function Row(x, y, w, h, metadb, idx, cur_playlist_idx_arg) {
         var right_pad = 0;
         var testRect = false;
 
-        var title_y = this.y;
-        var title_h = this.h;
-
         if (_.tf('$ifgreater(%totaldiscs%,1,true,false)', this.metadb) != 'false') {
             cur_x += 20;
         }
@@ -3543,7 +3538,7 @@ function Row(x, y, w, h, metadb, idx, cur_playlist_idx_arg) {
             if (length_text) {
                 var length_x = this.x + this.w - length_w - right_pad;
 
-                gr.DrawString(length_text, title_font, title_color, length_x, title_y, length_w, title_h, g_string_format.align_center);
+                gr.DrawString(length_text, title_font, title_color, length_x, this.y, length_w, this.h, g_string_format.align_center);
                 testRect && gr.DrawRect(length_x, this.y - 1, length_w, this.h, 1, _.RGBA(155, 155, 255, 250));
             }
             // We always want that padding
@@ -3566,7 +3561,7 @@ function Row(x, y, w, h, metadb, idx, cur_playlist_idx_arg) {
                 );
                 var count_x = this.x + this.w - count_w - right_pad;
 
-                gr.DrawString(count_text, g_pl_fonts.playcount, count_color, count_x, title_y, count_w, title_h, g_string_format.align_center);
+                gr.DrawString(count_text, g_pl_fonts.playcount, count_color, count_x, this.y, count_w, this.h, g_string_format.align_center);
                 testRect && gr.DrawRect(count_x, this.y - 1, count_w, this.h, 1, _.RGBA(155, 155, 255, 250));
 
                 right_pad += count_w;
@@ -3605,13 +3600,13 @@ function Row(x, y, w, h, metadb, idx, cur_playlist_idx_arg) {
             var title_w = this.w - right_pad - 10;
 
             var title_text_format = g_string_format.v_align_center | g_string_format.trim_ellipsis_char | g_string_format.no_wrap;
-            gr.DrawString(title_text + (title_artist_text ? '' : queue_text), title_font, title_color, cur_x, title_y, title_w, title_h, title_text_format);
+            gr.DrawString(title_text + (title_artist_text ? '' : queue_text), title_font, title_color, cur_x, this.y, title_w, this.h, title_text_format);
 
             testRect && gr.DrawRect(this.x, this.y - 1, title_w, this.h, 1, _.RGBA(155, 155, 255, 250));
 
             cur_x += Math.ceil(
                 /** @type {!number} */
-                gr.MeasureString(title_text, title_font, 0, 0, title_w, title_h, title_text_format | g_string_format.measure_trailing_spaces).Width
+                gr.MeasureString(title_text, title_font, 0, 0, title_w, this.h, title_text_format | g_string_format.measure_trailing_spaces).Width
             );
         }
 
@@ -3621,7 +3616,7 @@ function Row(x, y, w, h, metadb, idx, cur_playlist_idx_arg) {
             var title_artist_w = this.w - (title_artist_x - this.x) - right_pad;
 
             var title_artist_text_format = g_string_format.v_align_center | g_string_format.trim_ellipsis_char | g_string_format.no_wrap;
-            gr.DrawString(title_artist_text + queue_text, title_artist_font, title_artist_color, title_artist_x, title_y, title_artist_w, this.h, title_artist_text_format);
+            gr.DrawString(title_artist_text + queue_text, title_artist_font, title_artist_color, title_artist_x, this.y, title_artist_w, this.h, title_artist_text_format);
         }
     };
 

--- a/theme/Scripts/Panel_Playlist.js
+++ b/theme/Scripts/Panel_Playlist.js
@@ -3418,12 +3418,12 @@ function DiscHeader(x, y, w, h, metadb, header) {
 
         if (this.is_collapsed) {
             var line_y = Math.round(this.y + this.h / 2) - 2;
-            gr.DrawLine(cur_x + disc_w, line_y, this.x + this.w - tracks_w - 5, line_y, 1, _.rgba(100,100,100,100));
+            gr.DrawLine(cur_x + disc_w, line_y, this.x + this.w - tracks_w - 5, line_y, 1, _.RGBA(100,100,100,100));
             line_y += 4;
-            gr.DrawLine(cur_x + disc_w, line_y, this.x + this.w - tracks_w - 5, line_y, 1, _.rgba(100,100,100,100));
+            gr.DrawLine(cur_x + disc_w, line_y, this.x + this.w - tracks_w - 5, line_y, 1, _.RGBA(100,100,100,100));
         } else {
             var line_y = Math.round(this.y + this.h / 2);
-            gr.DrawLine(cur_x + disc_w, line_y, this.x + this.w - tracks_w - 5, line_y, 1, _.rgba(100,100,100,100));
+            gr.DrawLine(cur_x + disc_w, line_y, this.x + this.w - tracks_w - 5, line_y, 1, _.RGBA(100,100,100,100));
         }
     };
 

--- a/theme/Scripts/Panel_Playlist.js
+++ b/theme/Scripts/Panel_Playlist.js
@@ -34,6 +34,7 @@ g_properties.add_properties(
         auto_album_art:     ['user.header.this.art.auto', false],
         show_group_info:    ['user.header.info.show', true],
         show_original_date: ['user.header.original_date.show', false],
+        show_disc_headers:  ['user.header.disc_headers.show', true],
 
         alternate_row_color:  ['user.row.alternate_color', true],
         show_playcount:       ['user.row.play_count.show', _.cc('foo_playcount')],
@@ -1689,7 +1690,9 @@ function Playlist(x, y) {
             playlist_copy.length = playlist_copy.length - header.rows.length; ///< much faster then _.drop or slice, since it does not create a new array
             playlist_copy.reverse();
 
-            header.init_disc_rows(that);
+            if (g_properties.show_disc_headers) {
+                header.init_disc_rows(that);
+            }
             headers.push(header);
             ++head_nr;
         }
@@ -3239,8 +3242,8 @@ function Header(x, y, w, h, idx, row_h_arg) {
 
     this.init_disc_rows = function (that) {
         var disc, lastDisc = '';
-        var tfo = fb.TitleFormat('$ifgreater(%totaldiscs%,1,,false)[' + tf.disc_subtitle + ']');
-        var disc_group = fb.TitleFormat('%album artist% %album% %edition% %discnumber%' + tf.disc_subtitle);
+        var tfo = fb.TitleFormat('$ifgreater(%totaldiscs%,1,,false)[%discsubtitle%]');
+        var disc_group = fb.TitleFormat('%album artist% %album% %edition% %discnumber% %discsubtitle%');
         var disc_nr = 0;
         var startIndex;
         var disc_header = null;
@@ -3376,7 +3379,7 @@ function DiscHeader(x, y, w, h, metadb, header) {
         }
 
         var disc_header_text_format = g_string_format.v_align_center | g_string_format.trim_ellipsis_char | g_string_format.no_wrap;
-        var disc_text = _.tf('[Disc %discnumber% $if('+ tf.disc_subtitle+', \u2014 ,) ]['+ tf.disc_subtitle +']', that.metadb);
+        var disc_text = _.tf('[Disc %discnumber% $if(%discsubtitle%, \u2014 ,) ][%discsubtitle%]', that.metadb);
         gr.DrawString(disc_text, title_font, title_color, cur_x, this.y, this.w, this.h, disc_header_text_format);
 
         var tracks_text = this.rows.length + ' Track' + (this.rows.length > 1 ? 's' : '') + ' - ' + get_duration();

--- a/theme/Scripts/Panel_Playlist.js
+++ b/theme/Scripts/Panel_Playlist.js
@@ -2320,6 +2320,7 @@ function Playlist(x, y) {
         }
 
         var has_headers = g_properties.show_header;
+        var has_disc_headers = g_properties.show_disc_headers;
 
         var from_header = from_row ? from_row.header : undefined;
         var to_header = to_row.header;
@@ -2348,20 +2349,33 @@ function Playlist(x, y) {
                             || is_from_header && !is_to_header && from_header.idx + 1 === to_header.idx && to_item.idx === _.head(to_header.rows).idx
                             || !is_from_header && is_to_header && from_header.idx + 1 === to_header.idx && from_item.idx === _.last(from_header.rows).idx;
 
-
                         var row_shift = from_item_state.invisible_part + to_item_h_in_rows;
                         if (is_item_prev) {
                             if (has_headers && !is_from_header && !is_to_header && to_item.idx === _.last(to_header.rows).idx) {
                                 var from_header_state = get_item_visibility_state(from_header);
                                 row_shift += from_header_state.invisible_part;
+                                if (_.isInstanceOf(_.head(from_header.rows), DiscHeader)) {
+                                    row_shift++;
+                                }
+                            }
+                            else if (has_disc_headers && !is_to_header && to_item.num_in_header === from_row.num_in_header - 2) {
+                                // has DiscHeader between items
+                                row_shift += 1;
                             }
                             that.scrollbar.scroll_to(g_properties.scroll_pos - row_shift);
                             shifted_successfully = true;
                         }
                         else if (is_item_next) {
-                            if (has_headers && !is_to_header && to_item.idx === _.head(to_header.rows).idx) {
+                            if (has_headers && !is_to_header && (to_item.idx === _.head(to_header.rows).idx || to_item.num_in_header === 2)) {
                                 var to_header_state = get_item_visibility_state(to_header);
                                 row_shift += to_header_state.invisible_part;
+                                if (_.isInstanceOf(_.head(to_header.rows), DiscHeader)) {
+                                    row_shift++;
+                                }
+                            }
+                            else if (has_disc_headers && !is_to_header && to_item.num_in_header === from_row.num_in_header + 2) {
+                                // has DiscHeader between items
+                                row_shift += 1;
                             }
 
                             that.scrollbar.scroll_to(g_properties.scroll_pos + row_shift);

--- a/theme/Scripts/Panel_Playlist.js
+++ b/theme/Scripts/Panel_Playlist.js
@@ -1372,8 +1372,15 @@ function Playlist(x, y) {
                 var new_focus_item;
                 if (this.is_scrollbar_available) {
                     new_focus_item = _.head(this.items_to_draw);
+                    if (_.isInstanceOf(new_focus_item, DiscHeader)) {
+                        new_focus_item = this.items_to_draw[1]; // this will not work if we can collapse DiscHeaders
+                    }
                     if (_.isInstanceOf(new_focus_item, Header)) {
-                        new_focus_item = this.cnt.rows[_.head(new_focus_item.rows).idx];
+                        if (_.isInstanceOf(_.head(new_focus_item.rows), DiscHeader)) {
+                            new_focus_item = _.head(new_focus_item.rows).rows[0];   // first row in DiscHeader
+                        } else {
+                            new_focus_item = this.cnt.rows[_.head(new_focus_item.rows).idx];
+                        }
                     }
                     if (new_focus_item.y < this.list_y && new_focus_item.y + new_focus_item.h > this.list_y) {
                         new_focus_item = this.cnt.rows[new_focus_item.idx + 1];
@@ -1383,7 +1390,11 @@ function Playlist(x, y) {
 
                         new_focus_item = _.head(this.items_to_draw);
                         if (_.isInstanceOf(new_focus_item, Header)) {
-                            new_focus_item = this.cnt.rows[_.head(new_focus_item.rows).idx];
+                            if (_.isInstanceOf(_.head(new_focus_item.rows), DiscHeader)) {
+                                new_focus_item = _.head(new_focus_item.rows).rows[0];   // first row in DiscHeader
+                            } else {
+                                new_focus_item = this.cnt.rows[_.head(new_focus_item.rows).idx];
+                            }
                         }
                     }
                 }
@@ -1409,6 +1420,9 @@ function Playlist(x, y) {
                 var new_focus_item;
                 if (this.is_scrollbar_available) {
                     new_focus_item = _.last(this.items_to_draw);
+                    if (_.isInstanceOf(new_focus_item, DiscHeader)) {
+                        new_focus_item = this.items_to_draw[this.items_to_draw.length - 2]; // this will not work if we can collapse DiscHeaders
+                    }
                     if (_.isInstanceOf(new_focus_item, Header)) {
                         new_focus_item = _.last(this.cnt.headers[new_focus_item.idx - 1].rows);
                     }
@@ -1421,6 +1435,9 @@ function Playlist(x, y) {
                         new_focus_item = _.last(this.items_to_draw);
                         if (_.isInstanceOf(new_focus_item, Header)) {
                             new_focus_item = _.last(this.cnt.headers[new_focus_item.idx - 1].rows);
+                        }
+                        if (_.isInstanceOf(new_focus_item, DiscHeader)) {
+                            new_focus_item = this.items_to_draw[this.items_to_draw.length - 2]; // this will not work if we can collapse DiscHeaders
                         }
                     }
                 }

--- a/theme/Scripts/Panel_Playlist.js
+++ b/theme/Scripts/Panel_Playlist.js
@@ -3981,12 +3981,12 @@ function SelectionHandler(rows_arg, cur_playlist_idx_arg) {
 
         var is_drop_top_selected = is_above;
         var is_drop_bottom_selected = !is_above;
-        var is_drop_boundary_reached = hover_row.idx === 0 || (!is_above && hover_row.idx === rows.length - 1);
+        var is_drop_boundary_reached = hover_row.num_in_header === 0 || (!is_above && hover_row.num_in_header === rows.length - 1);
 
         if (is_internal_drag_n_drop_active && !utils.IsKeyPressed(VK_CONTROL)) {
             // Can't move selected item on itself
-            var is_item_above_selected = hover_row.idx !== 0 && rows[hover_row.idx - 1].is_selected();
-            var is_item_below_selected = hover_row.idx !== (rows.length - 1) && rows[hover_row.idx + 1].is_selected();
+            var is_item_above_selected = hover_row.num_in_header !== 0 && rows[hover_row.num_in_header - 1].is_selected();
+            var is_item_below_selected = hover_row.num_in_header !== (rows.length - 1) && rows[hover_row.num_in_header + 1].is_selected();
             is_drop_top_selected &= !hover_row.is_selected() && !is_item_above_selected;
             is_drop_bottom_selected &= !hover_row.is_selected() && !is_item_below_selected;
         }
@@ -3995,7 +3995,7 @@ function SelectionHandler(rows_arg, cur_playlist_idx_arg) {
 
         var needs_repaint = false;
         if (last_hover_row) {
-            if (last_hover_row.idx === cur_hover_item.idx) {
+            if (last_hover_row.num_in_header === cur_hover_item.num_in_header) {
                 needs_repaint = last_hover_row.is_drop_top_selected !== is_drop_top_selected
                     || last_hover_row.is_drop_bottom_selected !== is_drop_bottom_selected
                     || last_hover_row.is_drop_boundary_reached !== is_drop_boundary_reached;


### PR DESCRIPTION
This is a WIP for DiscHeaders that I thought you might find useful/interesting. I implemented it "correctly" using a DiscHeader class, which is treated identically to a normal Row except for how it draws. All the heavy lifting is done by `init_disc_rows()` which creates the DiscHeaders, inserts them into the Header.rows array, and places all the rows as references into the DiscHeader (needed for calculating total time).

I had originally tried to make them a distinct object that lived on Header which made more sense logically, but it turned `generate_all_items_to_draw` and `generate_first_item_to_draw` into horrible nested if nightmares, and I could never figure out the math correctly for first_item.

Things that don't work fully:
 - ~~Some visual issues exist (particularly position of right justified track nums/time)~~
 - Toggling works fine, but I cannot get list to redraw - because of this, I disabled toggling ability
 - generate_first_item_to_draw does not handle collapsed DiscHeaders yet

In my tests enabling disc headers added 80-100% time increase to init_headers. I optimized it as best I could, but I don't think it's possible to really bring that down much.